### PR TITLE
Significant formatting.

### DIFF
--- a/include/xieite/data/fixed_array.hpp
+++ b/include/xieite/data/fixed_array.hpp
@@ -32,13 +32,12 @@ namespace xieite {
 
 		Value array[length];
 
-		// NOTE(Hurubon): Can this be (conditionally) `noexcept`?
 		[[nodiscard]] friend constexpr auto operator<=>(
 			const xieite::fixed_array<Value, length>& lhs,
 			const xieite::fixed_array<Value, length>& rhs
-		) {
-			return xieite::range_cmp(lhs, rhs);
-		}
+		) XIEITE_ARROW(
+			xieite::range_cmp(lhs, rhs)
+		)
 
 		[[nodiscard]] constexpr auto&& operator[](
 			this auto&& self,


### PR DESCRIPTION
Reformatted the code to use a 90 character ruler for better visibility on smaller displays and window sizes (most of the code uses an 80 character ruler).
Added some formatting suggestions.
Found an issue - my editor can't highlight this section properly: 
<img width="753" height="515" alt="image" src="https://github.com/user-attachments/assets/0d3464b4-d355-4ac9-9ecc-10bc91f7b4ce" />
