### PR TITLE
Formatting.

### DIFF
--- a/include/xieite/data/fixed_map.hpp
+++ b/include/xieite/data/fixed_map.hpp
@@ -79,7 +79,8 @@ namespace xieite {
 				Map map;
 				map.reserve(this->array.size());
 				for (const std::pair<Key, Value>& entry : this->array) {
-					// Disregard constness here; it is properly handled in `operator[]()`
+					// Disregard constness here;
+					// it is properly handled in `operator[]()`
 					map.emplace(std::make_pair(
 						entry.first,
 						const_cast<Value*>(std::addressof(entry.second))


### PR DESCRIPTION
Reformatted the code to use an 80 character ruler for better visibility on smaller displays and window sizes.
Reformatted the code to use `std::invoke` for immediately-invoked function expressions.