### PR TITLE
Formatting.

### DIFF
--- a/include/xieite/data/make_array.hpp
+++ b/include/xieite/data/make_array.hpp
@@ -12,18 +12,29 @@
 #	include "../trait/is_noex_lref_invoc.hpp"
 
 namespace xieite {
-	template<typename Value, std::size_t length, std::ranges::input_range Range = std::initializer_list<Value>, xieite::is_lref_invoc<Value(std::ranges::range_common_reference_t<Range>)> Conv = std::identity>
-	[[nodiscard]] constexpr std::array<Value, length> make_array(Range&& range, Conv&& conv = {})
-	noexcept(xieite::is_noex_lref_invoc<Conv, Value(std::ranges::range_common_reference_t<Range>)>) {
-		return xieite::unroll<length>([&range, &conv]<std::size_t... i> -> std::array<Value, length> {
+	template<
+		typename Value,
+		std::size_t length,
+		std::ranges::input_range Range = std::initializer_list<Value>,
+		xieite::is_lref_invoc<Value(
+			std::ranges::range_common_reference_t<Range>
+		)> Conv = std::identity
+	> [[nodiscard]] constexpr std::array<Value, length> make_array(
+		Range&& range,
+		Conv&& conv = {}
+	) noexcept(xieite::is_noex_lref_invoc<Conv, Value(
+		std::ranges::range_common_reference_t<Range>
+	  )>
+	) {
+		return xieite::unroll<length>([&range, &conv]<std::size_t... i> {
 			auto iter = std::ranges::begin(range);
 			return std::array<Value, length> {
-				([&conv, &iter] -> decltype(auto) {
+				std::invoke([&conv, &iter] -> decltype(auto) {
 					if constexpr (i > 0) {
 						++iter;
 					}
 					return std::invoke(conv, std::forward_like<Range>(*iter));
-				})()...
+				})...
 			};
 		});
 	}

--- a/include/xieite/data/make_ptr.hpp
+++ b/include/xieite/data/make_ptr.hpp
@@ -23,34 +23,54 @@ namespace xieite {
 
 	template<typename Value>
 	requires(!xieite::is_unbounded_array<Value>)
-	[[nodiscard]] constexpr xieite::ptr<Value> make_ptr_init(auto&&... args) noexcept(false) {
+	[[nodiscard]] constexpr xieite::ptr<Value> make_ptr_init(
+		auto&&... args
+	) noexcept(false) {
 		return xieite::ptr<Value>(new Value(XIEITE_FWD(args)...));
 	}
 
 	template<typename Value>
 	requires(!xieite::is_unbounded_array<Value>)
-	[[nodiscard]] constexpr xieite::ptr<Value> make_ptr_noex_init(auto&&... args) noexcept {
+	[[nodiscard]] constexpr xieite::ptr<Value> make_ptr_noex_init(
+		auto&&... args
+	) noexcept {
 		return xieite::ptr<Value>(new(std::nothrow) Value(XIEITE_FWD(args)...));
 	}
 
 	template<xieite::is_unbounded_array Array>
-	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr(std::size_t length) noexcept(false) {
-		return xieite::ptr<Array>(new std::remove_extent_t<Array>[length]);
+	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr(
+		std::size_t length
+	) noexcept(false) {
+		using Bounded = std::remove_extent_t<Array>[length];
+		return xieite::ptr<Array>(new Bounded);
 	}
 
 	template<xieite::is_unbounded_array Array>
-	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_noex(std::size_t length) noexcept {
-		return xieite::ptr<Array>(new(std::nothrow) std::remove_extent_t<Array>[length]);
+	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_noex(
+		std::size_t length
+	) noexcept {
+		using Bounded = std::remove_extent_t<Array>[length];
+		return xieite::ptr<Array>(new(std::nothrow) Bounded);
 	}
 
 	template<xieite::is_unbounded_array Array>
-	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_init(std::size_t length, auto&&... args) noexcept(false) {
-		return xieite::ptr<Array>(new std::remove_extent_t<Array>[length] { XIEITE_FWD(args)... });
+	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_init(
+		std::size_t length,
+		auto&&... args
+	) noexcept(false) {
+		using Bounded = std::remove_extent_t<Array>[length];
+		return xieite::ptr<Array>(new Bounded { XIEITE_FWD(args)... });
 	}
 
 	template<xieite::is_unbounded_array Array>
-	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_noex_init(std::size_t length, auto&&... args) noexcept {
-		return xieite::ptr<Array>(new(std::nothrow) std::remove_extent_t<Array>[length] { XIEITE_FWD(args)... });
+	[[nodiscard]] constexpr xieite::ptr<Array> make_ptr_noex_init(
+		std::size_t length,
+		auto&&... args
+	) noexcept {
+		using Bounded = std::remove_extent_t<Array>[length];
+		return xieite::ptr<Array>(new(std::nothrow) Bounded {
+			XIEITE_FWD(args)...
+		});
 	}
 }
 

--- a/include/xieite/data/make_sparse_array.hpp
+++ b/include/xieite/data/make_sparse_array.hpp
@@ -17,16 +17,37 @@
 #	include "../trait/is_noex_lref_invoc.hpp"
 
 namespace xieite {
-	template<typename Key, typename Value, std::ranges::input_range Range = std::initializer_list<std::pair<Key, Value>>, xieite::is_lref_invoc<std::pair<Key, Value>(std::ranges::range_common_reference_t<Range>)> Conv = std::identity>
-	requires(std::integral<Key> || xieite::is_enum<Key>)
-	[[nodiscard]] constexpr std::array<Value, (1uz << xieite::bit_size<Key>)> make_sparse_array(Range&& entries, Conv&& conv = {})
-	noexcept(xieite::is_noex_lref_invoc<Conv, std::pair<Key, Value>(std::ranges::range_common_reference_t<Range>)>) {
-		static_assert(xieite::bit_size<Key> <= 16, "key type must be reasonably small");
-		static_assert(xieite::arity<std::ranges::range_value_t<Range>> == 2, "range entries must each have one key and one value");
+	template<
+		typename Key,
+		typename Value,
+		std::ranges::input_range Range = std::initializer_list<
+			std::pair<Key, Value>
+		>,
+		xieite::is_lref_invoc<std::pair<Key, Value>(
+			std::ranges::range_common_reference_t<Range>
+		)> Conv = std::identity
+	> requires(std::integral<Key> || xieite::is_enum<Key>)
+	[[nodiscard]] constexpr std::array<Value, (1uz << xieite::bit_size<Key>)>
+	make_sparse_array(
+		Range&& entries,
+		Conv&& conv = {}
+	) noexcept(xieite::is_noex_lref_invoc<Conv, std::pair<Key, Value>(
+		std::ranges::range_common_reference_t<Range>
+	  )>
+	) {
+		static_assert(
+			xieite::bit_size<Key> <= 16,
+			"Key type must be reasonably small."
+		);
+		static_assert(
+			xieite::arity<std::ranges::range_value_t<Range>> == 2,
+			"Range entries must each have one key and one value."
+		);
 		auto result = std::array<Value, (1uz << xieite::bit_size<Key>)>();
 		for (auto&& entry : XIEITE_FWD(entries)) {
 			auto&& [key, value] = std::invoke(conv, XIEITE_FWD(entry));
-			result[xieite::sign_cast<std::size_t>(xieite::to_underlying(key))] = XIEITE_FWD(value);
+			result[xieite::sign_cast<std::size_t>(xieite::to_underlying(key))]
+				= XIEITE_FWD(value);
 		}
 		return result;
 	}

--- a/include/xieite/data/make_str_view.hpp
+++ b/include/xieite/data/make_str_view.hpp
@@ -9,29 +9,45 @@
 #	include "../trait/rm_ref.hpp"
 
 namespace xieite {
+	// FIXME(Hurubon): Make this XIEITE_ARROW?
 	template<xieite::is_char Char, typename Traits>
-	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(std::basic_string_view<Char, Traits> strv) noexcept {
+	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(
+		std::basic_string_view<Char, Traits> strv
+	) noexcept {
 		return strv;
 	}
 
 	template<xieite::is_char Char, typename Traits, typename Alloc>
-	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(const std::basic_string<Char, Traits, Alloc>& str) noexcept {
+	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(
+		const std::basic_string<Char, Traits, Alloc>& str
+	) noexcept {
 		return std::basic_string_view<Char, Traits>(str);
 	}
 
 	template<xieite::is_char Char, typename Traits = std::char_traits<Char>>
-	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(const Char* str, std::size_t length) noexcept {
-		return std::basic_string_view<Char, Traits>(str, length - (length && !str[length - 1]));
+	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(
+		const Char* str, std::size_t length
+	) noexcept {
+		return std::basic_string_view<Char, Traits>(
+			str,
+			length - (length && !str[length - 1])
+		);
 	}
 
-	template<xieite::is_char Char, typename Traits = std::char_traits<Char>, std::size_t length>
-	[[nodiscard]] constexpr std::basic_string_view<Char, Traits> make_str_view(const xieite::type<Char[length]>& str) noexcept {
+	template<
+		xieite::is_char Char,
+		typename Traits = std::char_traits<Char>, std::size_t length
+	> [[nodiscard]] constexpr std::basic_string_view<Char, Traits>
+	make_str_view(const xieite::type<Char[length]>& str) noexcept {
 		return xieite::make_str_view<Char, Traits>(*&str, length);
 	}
 
-	template<typename Char, typename Traits = std::char_traits<xieite::rm_ref<Char>>>
-	requires(xieite::is_char<xieite::rm_ref<Char>>)
-	[[nodiscard]] constexpr std::basic_string_view<xieite::rm_ref<Char>, Traits> make_str_view(Char&& c = {}) noexcept {
+	template<
+		typename Char,
+		typename Traits = std::char_traits<xieite::rm_ref<Char>>
+	> requires(xieite::is_char<xieite::rm_ref<Char>>)
+	[[nodiscard]] constexpr std::basic_string_view<xieite::rm_ref<Char>, Traits>
+	make_str_view(Char&& c = {}) noexcept {
 		return std::basic_string_view<xieite::rm_ref<Char>, Traits>(&c, 1);
 	}
 }

--- a/include/xieite/data/md_container.hpp
+++ b/include/xieite/data/md_container.hpp
@@ -7,12 +7,22 @@
 
 namespace DETAIL_XIEITE::md_container {
 	template<template<typename> typename Container>
-	constexpr auto impl = []<typename Prev, auto> { return xieite::wrap_type<Container<typename Prev::type>>(); };
+	constexpr auto impl = []<typename Prev, auto> {
+		return xieite::wrap_type<Container<typename Prev::type>>();
+	};
 }
 
 namespace xieite {
-	template<template<typename> typename Container, typename Value, std::size_t rank>
-	using md_container = xieite::fold_for<DETAIL_XIEITE::md_container::impl<Container>, xieite::wrap_type<Value>, rank>::type;
+	template<
+		template<typename> typename Container,
+		typename Value,
+		std::size_t rank
+	>
+	using md_container = xieite::fold_for<
+		DETAIL_XIEITE::md_container::impl<Container>,
+		xieite::wrap_type<Value>,
+		rank
+	>::type;
 }
 
 #endif

--- a/include/xieite/data/number_str_config.hpp
+++ b/include/xieite/data/number_str_config.hpp
@@ -8,11 +8,11 @@
 namespace xieite {
 	struct number_str_config {
 		std::string_view digits = xieite::chars::alphanumeric;
-		std::string_view minus = "-";
-		std::string_view plus = "+";
-		std::string_view point = ".";
-		std::string_view exp = "EePp";
-		std::size_t precision = 50;
+		std::string_view minus  = "-";
+		std::string_view plus   = "+";
+		std::string_view point  = ".";
+		std::string_view exp    = "EePp";
+		std::size_t precision   = 50;
 	};
 }
 

--- a/include/xieite/data/pad.hpp
+++ b/include/xieite/data/pad.hpp
@@ -9,22 +9,58 @@
 #	include "../trait/is_char.hpp"
 
 namespace xieite {
-	template<xieite::is_char Char, typename Traits, typename Alloc>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(const std::basic_string<Char, Traits, Alloc>& str, std::size_t target_length, Char c = ' ', bool align_front = true, const Alloc& alloc = {}) noexcept(false) {
-		using Str = std::basic_string<Char, Traits, Alloc>;
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(
+		const std::basic_string<Char, Traits, Alloc>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		bool align_front = true,
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		const auto padding_l = (target_length - str.size() + !align_front) / 2;
+		const auto padding_r = (target_length - str.size() +  align_front) / 2;
 		return (str.size() < target_length)
-			? Str((target_length - str.size() + !align_front) / 2, c, alloc) + str + Str((target_length - str.size() + align_front) / 2, c, alloc)
+			? String(padding_l, c, alloc) + str + String(padding_r, c, alloc)
 			: str;
 	}
 
-	template<xieite::is_char Char, typename Traits, typename Alloc = std::allocator<Char>>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(std::basic_string_view<Char, Traits> strv, std::size_t target_length, Char c = ' ', bool align_front = true, const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad(std::basic_string<Char, Traits, Alloc>(strv, alloc), target_length, c, align_front, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc = std::allocator<Char>
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(
+		std::basic_string_view<Char, Traits> strv,
+		std::size_t target_length,
+		Char c = ' ',
+		bool align_front = true,
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad(
+			String(strv, alloc), target_length, c, align_front, alloc
+		);
 	}
 
-	template<xieite::is_char Char, typename Traits = std::char_traits<Char>, typename Alloc = std::allocator<Char>, std::size_t length>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(const xieite::type<Char[length]>& str, std::size_t target_length, Char c = ' ', bool align_front = true, const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad(std::basic_string<Char, Traits, Alloc>(str, length, alloc), target_length, c, align_front, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits = std::char_traits<Char>,
+		typename Alloc = std::allocator<Char>,
+		std::size_t length
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad(
+		const xieite::type<Char[length]>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		bool align_front = true,
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad(
+			String(str, length, alloc), target_length, c, align_front, alloc
+		);
 	}
 }
 

--- a/include/xieite/data/pad_back.hpp
+++ b/include/xieite/data/pad_back.hpp
@@ -9,21 +9,51 @@
 #	include "../trait/is_char.hpp"
 
 namespace xieite {
-	template<xieite::is_char Char, typename Traits, typename Alloc>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(const std::basic_string<Char, Traits, Alloc>& str, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(
+		const std::basic_string<Char, Traits, Alloc>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
 		return (str.size() < target_length)
-			? (str + std::basic_string<Char, Traits, Alloc>(target_length - str.size(), c, alloc))
+			? (str + String(target_length - str.size(), c, alloc))
 			: str;
 	}
 
-	template<xieite::is_char Char, typename Traits, typename Alloc = std::allocator<Char>>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(std::basic_string_view<Char, Traits> strv, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad_back(std::basic_string<Char, Traits, Alloc>(strv, alloc), target_length, c, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc = std::allocator<Char>
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(
+		std::basic_string_view<Char, Traits> strv,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad_back(String(strv, alloc), target_length, c, alloc);
 	}
 
-	template<xieite::is_char Char, typename Traits = std::char_traits<Char>, typename Alloc = std::allocator<Char>, std::size_t length>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(const xieite::type<Char[length]>& str, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad_back(std::basic_string<Char, Traits, Alloc>(str, length, alloc), target_length, c, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits = std::char_traits<Char>,
+		typename Alloc = std::allocator<Char>,
+		std::size_t length
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_back(
+		const xieite::type<Char[length]>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad_back(
+			String(str, length, alloc), target_length, c, alloc
+		);
 	}
 }
 

--- a/include/xieite/data/pad_front.hpp
+++ b/include/xieite/data/pad_front.hpp
@@ -9,21 +9,51 @@
 #	include "../trait/is_char.hpp"
 
 namespace xieite {
-	template<xieite::is_char Char, typename Traits, typename Alloc>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(const std::basic_string<Char, Traits, Alloc>& str, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc
+	>  [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(
+		const std::basic_string<Char, Traits, Alloc>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
 		return (str.size() < target_length)
-			? (std::basic_string<Char, Traits, Alloc>(target_length - str.size(), c, alloc) + str)
+			? (String(target_length - str.size(), c, alloc) + str)
 			: str;
 	}
 
-	template<xieite::is_char Char, typename Traits, typename Alloc = std::allocator<Char>>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(std::basic_string_view<Char, Traits> strv, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad_front(std::basic_string<Char, Traits, Alloc>(strv, alloc), target_length, c, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits,
+		typename Alloc = std::allocator<Char>
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(
+		std::basic_string_view<Char, Traits> strv,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad_front(String(strv, alloc), target_length, c, alloc);
 	}
 
-	template<xieite::is_char Char, typename Traits = std::char_traits<Char>, typename Alloc = std::allocator<Char>, std::size_t length>
-	[[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(const xieite::type<Char[length]>& str, std::size_t target_length, Char c = ' ', const Alloc& alloc = {}) noexcept(false) {
-		return xieite::pad_front(std::basic_string<Char, Traits, Alloc>(str, length, alloc), target_length, c, alloc);
+	template<
+		xieite::is_char Char,
+		typename Traits = std::char_traits<Char>,
+		typename Alloc = std::allocator<Char>,
+		std::size_t length
+	> [[nodiscard]] constexpr std::basic_string<Char, Traits, Alloc> pad_front(
+		const xieite::type<Char[length]>& str,
+		std::size_t target_length,
+		Char c = ' ',
+		const Alloc& alloc = {}
+	) noexcept(false) {
+		using String = std::basic_string<Char, Traits, Alloc>;
+		return xieite::pad_front(
+			String(str, length, alloc), target_length, c, alloc
+		);
 	}
 }
 

--- a/include/xieite/data/palindrome.hpp
+++ b/include/xieite/data/palindrome.hpp
@@ -10,18 +10,31 @@
 #	include "../trait/is_noex_range.hpp"
 
 namespace xieite {
-	template<std::ranges::forward_range Range, xieite::is_lref_invoc<bool(std::ranges::range_common_reference_t<Range>, std::ranges::range_common_reference_t<Range>)> Pred = std::equal_to<>>
-	requires(std::ranges::sized_range<Range>)
+	template<
+		// FIXME(Hurubon): Make this bidirectional_range.
+		std::ranges::forward_range Range,
+		xieite::is_lref_invoc<bool(
+			std::ranges::range_common_reference_t<Range>,
+			std::ranges::range_common_reference_t<Range>
+		)> Pred = std::equal_to<>
+	> requires(std::ranges::sized_range<Range>)
 	[[nodiscard]] constexpr bool palindrome(Range&& range, Pred&& pred = {})
-	noexcept(xieite::is_noex_range<Range> && xieite::is_noex_lref_invoc<Pred, bool(std::ranges::range_common_reference_t<Range>, std::ranges::range_common_reference_t<Range>)>) {
-		auto iter0 = std::ranges::begin(range);
-		auto iter1 = std::ranges::end(range);
-		for (std::size_t i = std::ranges::size(range) / 2; i--;) {
-			--iter1;
-			if (!std::invoke_r<bool>(pred, *iter0, *iter1)) {
+	noexcept(
+		xieite::is_noex_range<Range>
+		&& xieite::is_noex_lref_invoc<Pred, bool(
+			std::ranges::range_common_reference_t<Range>,
+			std::ranges::range_common_reference_t<Range>
+		)>
+	) {
+		auto left_to_right = std::ranges::begin(range);
+		auto right_to_left = std::ranges::end(range);
+		// FIXME(Hurubon): Explicitly compare i-- against 0?
+		for (std::size_t i = std::ranges::size(range) / 2; i--; ) {
+			--right_to_left;
+			if (!std::invoke_r<bool>(pred, *left_to_right, *right_to_left)) {
 				return false;
 			}
-			++iter0;
+			++left_to_right;
 		}
 		return true;
 	}

--- a/include/xieite/data/partial_reverse.hpp
+++ b/include/xieite/data/partial_reverse.hpp
@@ -9,15 +9,24 @@
 #	include "../trait/is_noex_range.hpp"
 
 namespace xieite {
-	template<std::ranges::bidirectional_range Range, xieite::is_lref_invoc<bool(std::ranges::range_common_reference_t<Range>)> Pred>
-	requires(std::indirectly_swappable<std::ranges::iterator_t<Range>>)
+	template<
+		std::ranges::bidirectional_range Range,
+		xieite::is_lref_invoc<bool(
+			std::ranges::range_common_reference_t<Range>
+		)> Pred
+	> requires(std::indirectly_swappable<std::ranges::iterator_t<Range>>)
 	constexpr void partial_reverse(Range& range, Pred&& pred = {})
-	noexcept(xieite::is_noex_range<Range> && xieite::is_noex_lref_invoc<Pred, bool(std::ranges::range_common_reference_t<Range>)>) {
+	noexcept(
+		xieite::is_noex_range<Range>
+		&& xieite::is_noex_lref_invoc<Pred, bool(
+			std::ranges::range_common_reference_t<Range>
+		)>
+	) {
 		auto first = std::ranges::begin(range);
-		auto last = std::ranges::end(range);
+		auto last  = std::ranges::end(range);
 		while (true) {
 			first = std::ranges::find_if(first, last, pred);
-			last = std::ranges::find_last_if(first, last, pred);
+			last  = std::ranges::find_last_if(first, last, pred);
 			if (first == last) {
 				break;
 			}


### PR DESCRIPTION
Reformatted the code to use an 80 character ruler for better visibility on smaller displays and window sizes.
Refactored the code to use `std::invoke` for immediately-invoked function expressions.
Refactored the code to use the `String` type alias in `pad.hpp`, `pad_front.hpp` and `pad_back.hpp` to match the original implementation in `pad`.
Refactored the code to use variable aliases for long formulas.