### PR TITLE
Use math instead of a switch statement for lowercase/uppercase

### DIFF
--- a/include/xte/data/lowercase.hpp
+++ b/include/xte/data/lowercase.hpp
@@ -12,61 +12,7 @@
 
 namespace xte {
 	[[nodiscard]] constexpr char lowercase(char c) noexcept {
-		switch (c) {
-			case 'A':
-				return 'a';
-			case 'B':
-				return 'b';
-			case 'C':
-				return 'c';
-			case 'D':
-				return 'd';
-			case 'E':
-				return 'e';
-			case 'F':
-				return 'f';
-			case 'G':
-				return 'g';
-			case 'H':
-				return 'h';
-			case 'I':
-				return 'i';
-			case 'J':
-				return 'j';
-			case 'K':
-				return 'k';
-			case 'L':
-				return 'l';
-			case 'M':
-				return 'm';
-			case 'N':
-				return 'n';
-			case 'O':
-				return 'o';
-			case 'P':
-				return 'p';
-			case 'Q':
-				return 'q';
-			case 'R':
-				return 'r';
-			case 'S':
-				return 's';
-			case 'T':
-				return 't';
-			case 'U':
-				return 'u';
-			case 'V':
-				return 'v';
-			case 'W':
-				return 'w';
-			case 'X':
-				return 'x';
-			case 'Y':
-				return 'y';
-			case 'Z':
-				return 'z';
-		}
-		return c;
+		return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - ('A' - 'a')) : c;
 	}
 
 	[[nodiscard]] constexpr xte::string lowercase(xte::string_view string) noexcept(false) {

--- a/include/xte/data/uppercase.hpp
+++ b/include/xte/data/uppercase.hpp
@@ -12,61 +12,7 @@
 
 namespace xte {
 	[[nodiscard]] constexpr char uppercase(char c) noexcept {
-		switch (c) {
-			case 'a':
-				return 'A';
-			case 'b':
-				return 'B';
-			case 'c':
-				return 'C';
-			case 'd':
-				return 'D';
-			case 'e':
-				return 'E';
-			case 'f':
-				return 'F';
-			case 'g':
-				return 'G';
-			case 'h':
-				return 'H';
-			case 'i':
-				return 'I';
-			case 'j':
-				return 'J';
-			case 'k':
-				return 'K';
-			case 'l':
-				return 'L';
-			case 'm':
-				return 'M';
-			case 'n':
-				return 'N';
-			case 'o':
-				return 'O';
-			case 'p':
-				return 'P';
-			case 'q':
-				return 'Q';
-			case 'r':
-				return 'R';
-			case 's':
-				return 'S';
-			case 't':
-				return 'T';
-			case 'u':
-				return 'U';
-			case 'v':
-				return 'V';
-			case 'w':
-				return 'W';
-			case 'x':
-				return 'X';
-			case 'y':
-				return 'Y';
-			case 'z':
-				return 'Z';
-		}
-		return c;
+		return (c >= 'a' && c <= 'z') ? static_cast<char>(c - ('a' - 'A')) : c;
 	}
 
 	[[nodiscard]] constexpr xte::string uppercase(xte::string_view string) noexcept(false) {


### PR DESCRIPTION
Is this intentional for systems that does not use ASCII? I doubt a compiler would not support ASCII in the year 2026. if so you might want to put a comment